### PR TITLE
feat(cmake): Improve cross platform cmake generation

### DIFF
--- a/cmakegen/exec.go
+++ b/cmakegen/exec.go
@@ -14,18 +14,21 @@ set(CMAKE_CXX_STANDARD {{.LanguageStandard}})
 
 add_executable({{.ProjectName}})
 
-target_sources({{.ProjectName}} PRIVATE {{.Sources}} {{.Includes}})
+target_sources({{.ProjectName}} PRIVATE
+	{{.Sources -}}
+	{{.Includes}}
+)
 {{$c3pmGlobalDir:=.C3pmGlobalDir}}
 
 target_include_directories(
-	{{.ProjectName}} PRIVATE {{.IncludeDirs}}
-	{{ range .Dependencies }}
-		{{$name:=.Name}}
-		{{$version:=.Version}}
-		{{ range .ExportedIncludeDirs }}
-			{{$c3pmGlobalDir}}/cache/{{$name}}/{{$version}}/{{.}}
-		{{ end }}
-	{{end}}
+	{{- .ProjectName}} PRIVATE {{.IncludeDirs}}
+	{{- range .Dependencies }}
+		{{- $name:=.Name }}
+		{{- $version:=.Version}}
+		{{- range .ExportedIncludeDirs }}
+	{{ $c3pmGlobalDir }}/cache/{{$name}}/{{$version}}/{{.}}
+		{{- end }}
+	{{- end }}
 )
 {{range .Dependencies}}
 find_library({{ .Name | ToUpper}} {{.Name}} "{{$c3pmGlobalDir}}/cache/{{.Name}}/{{.Version}}/lib")
@@ -36,7 +39,7 @@ target_link_libraries(
 	PUBLIC
 	{{range .Dependencies}}
 	{{"${"}}{{.Name|ToUpper}}{{"}"}}
-	{{end}}
+	{{- end}}
 )
 `
 

--- a/cmakegen/gen.go
+++ b/cmakegen/gen.go
@@ -26,7 +26,7 @@ type CMakeVars struct {
 	Includes         string
 	IncludeDirs      string
 	ExportedDir      string
-	Home             string
+	C3pmGlobalDir    string
 	Dependencies     []Dependency
 	PublicIncludeDir string
 	LinuxConfig      *manifest.LinuxConfig
@@ -103,7 +103,7 @@ func varsFromProjectConfig(pc *config.ProjectConfig) (CMakeVars, error) {
 		Includes:         filesSliceToCMake(pc.Manifest.Files.Includes),
 		IncludeDirs:      filesSliceToCMake(pc.Manifest.Files.IncludeDirs),
 		ExportedDir:      filepath.ToSlash(filepath.Join(pc.ProjectRoot, pc.Manifest.Files.ExportedDir)),
-		Home:             filepath.ToSlash(os.Getenv("HOME")),
+		C3pmGlobalDir:    filepath.ToSlash(config.GlobalC3pmDirPath()),
 		Dependencies:     dependencies,
 		LinuxConfig:      pc.Manifest.LinuxConfig,
 		LanguageStandard: pc.Manifest.Standard,

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 )
 
 type ProjectConfig struct {
@@ -48,7 +49,12 @@ func GlobalC3pmDirPath() string {
 	if dir := os.Getenv("C3PM_USER_DIR"); dir != "" {
 		return dir
 	}
-	homeDir := os.Getenv("HOME")
+	var homeDir string
+	if runtime.GOOS == "windows" {
+		homeDir = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
 	return path.Join(homeDir, ".c3pm")
 }
 

--- a/ctpm/build.go
+++ b/ctpm/build.go
@@ -11,8 +11,11 @@ import (
 func Build(pc *config.ProjectConfig) error {
 	cmakeVariables := map[string]string{
 		"CMAKE_LIBRARY_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
 		"CMAKE_ARCHIVE_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
 		"CMAKE_RUNTIME_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
 		"CMAKE_INSTALL_PREFIX":           filepath.ToSlash(filepath.Join(config.GlobalC3pmDirPath(), "cache", pc.Manifest.Name, pc.Manifest.Version.String())),
 		"CMAKE_BUILD_TYPE":               "Release",
 		// Useful for Windows build

--- a/ctpm/build.go
+++ b/ctpm/build.go
@@ -10,14 +10,14 @@ import (
 
 func Build(pc *config.ProjectConfig) error {
 	cmakeVariables := map[string]string{
-		"CMAKE_LIBRARY_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_LIBRARY_OUTPUT_DIRECTORY":         pc.ProjectRoot,
 		"CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
-		"CMAKE_ARCHIVE_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_ARCHIVE_OUTPUT_DIRECTORY":         pc.ProjectRoot,
 		"CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
-		"CMAKE_RUNTIME_OUTPUT_DIRECTORY": pc.ProjectRoot,
+		"CMAKE_RUNTIME_OUTPUT_DIRECTORY":         pc.ProjectRoot,
 		"CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE": pc.ProjectRoot,
-		"CMAKE_INSTALL_PREFIX":           filepath.ToSlash(filepath.Join(config.GlobalC3pmDirPath(), "cache", pc.Manifest.Name, pc.Manifest.Version.String())),
-		"CMAKE_BUILD_TYPE":               "Release",
+		"CMAKE_INSTALL_PREFIX":                   filepath.ToSlash(filepath.Join(config.GlobalC3pmDirPath(), "cache", pc.Manifest.Name, pc.Manifest.Version.String())),
+		"CMAKE_BUILD_TYPE":                       "Release",
 		// Useful for Windows build
 		//"MSVC_TOOLSET_VERSION":           "141",
 		//"MSVC_VERSION":                   "1916",


### PR DESCRIPTION
- Fix Home directory for windows
- add find_library in cmake (instead of "-L" or link_directories as it is recommend in [doc](https://cmake.org/cmake/help/latest/command/link_directories.html))