### PR TITLE
add: support for development and production environments

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/c3pm-labs/c3pm/env"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -19,7 +20,7 @@ type API struct {
 func (c API) newRequest(method string, path string, body io.Reader) (*http.Request, error) {
 	var host string
 	if customEndpoint := os.Getenv("C3PM_API_ENDPOINT"); customEndpoint == "" {
-		host = "https://c3pm.herokuapp.com/v1"
+		host = env.API_ENDPOINT
 	} else {
 		host = customEndpoint
 	}

--- a/ctpm/add.go
+++ b/ctpm/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/c3pm-labs/c3pm/cmake"
 	"github.com/c3pm-labs/c3pm/config"
 	"github.com/c3pm-labs/c3pm/config/manifest"
+	"github.com/c3pm-labs/c3pm/env"
 	"github.com/c3pm-labs/c3pm/registry"
 	"io"
 	"io/ioutil"
@@ -29,8 +30,6 @@ func Add(pc *config.ProjectConfig, opts AddOptions) error {
 	return nil
 }
 
-const DefaultRegistryUrl = "http://localhost:4444/v1"
-
 type AddOptions struct {
 	Force       bool
 	RegistryURL string
@@ -40,7 +39,7 @@ type AddOptions struct {
 
 func buildOptions(opts AddOptions) AddOptions {
 	if opts.RegistryURL == "" {
-		opts.RegistryURL = DefaultRegistryUrl
+		opts.RegistryURL = env.REGISTRY_ENDPOINT
 	}
 	return opts
 }

--- a/env/dev.go
+++ b/env/dev.go
@@ -1,0 +1,8 @@
+//+build dev
+
+package env
+
+const (
+	API_ENDPOINT      = "http://localhost:4000/v1"
+	REGISTRY_ENDPOINT = "http://localhost:4444/v1"
+)

--- a/env/prod.go
+++ b/env/prod.go
@@ -1,0 +1,8 @@
+//+build !dev
+
+package env
+
+const (
+	API_ENDPOINT      = "https://c3pm.herokuapp.com/v1"
+	REGISTRY_ENDPOINT = "https://registry.c3pm.io/v1"
+)


### PR DESCRIPTION
These changes will allow developers to build the cli using the following command to run the CLI in a development environment.

```go build -tags dev```
