### PR TITLE
fix(release): hardcode install command in generated brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,9 @@ brews:
   tap:
     owner: c3pm-labs
     name: homebrew-c3pm
+    install: |
+        bin.install "ctpm"
+
 nfpms:
 - homepage: c3pm.io
   maintainer: Codelax <Codelax@protonmail.com>


### PR DESCRIPTION
Default command install binary with name of the formula but our binary name is ctpm