### PR TITLE
feat: add test command

### DIFF
--- a/adapter/defaultadapter/config.go
+++ b/adapter/defaultadapter/config.go
@@ -10,6 +10,10 @@ type Config struct {
 	Sources []string `yaml:"sources"`
 	// Headers lists the project's header files.
 	Headers []string `yaml:"headers"`
+	// TestSources lists the project's tests source files
+	TestSources []string `yaml:"test_sources"`
+	// TestHeaders list the tests' header files
+	TestHeaders []string `yaml:"test_headers"`
 	// IncludeDirs lists the projects additional header directories.
 	IncludeDirs []string `yaml:"include_dirs"`
 	// LinuxConfig holds Linux specific configuration

--- a/adapter/defaultadapter/defaultadapter.go
+++ b/adapter/defaultadapter/defaultadapter.go
@@ -103,3 +103,23 @@ func cmakeDirFromPc(pc *config.ProjectConfig) string {
 func buildDirFromPc(pc *config.ProjectConfig) string {
 	return filepath.Join(pc.LocalC3PMDirPath(), "build")
 }
+
+func (a *DefaultAdapter) Test(pc *config.ProjectConfig) error {
+	adapterCfg, err := Parse(pc.Manifest.Build.Config)
+	if err != nil {
+		return err
+	}
+	sources := adapterCfg.Sources
+	headers := adapterCfg.Headers
+	name := pc.Manifest.Name
+	adapterCfg.Sources = adapterCfg.TestSources
+	adapterCfg.Headers = adapterCfg.TestHeaders
+	pc.Manifest.Name = pc.Manifest.Name + "_test"
+	pc.Manifest.Build.Config = adapterCfg
+	err = a.Build(pc)
+	adapterCfg.Sources = sources
+	adapterCfg.Headers = headers
+	pc.Manifest.Name = name
+	pc.Manifest.Build.Config = adapterCfg
+	return err
+}

--- a/adapter_interface/interface.go
+++ b/adapter_interface/interface.go
@@ -14,6 +14,11 @@ type Adapter interface {
 	CmakeConfig(pc *config.ProjectConfig) (string, error)
 }
 
+type AdapterTestable interface {
+	// Test run tests
+	Test(pc *config.ProjectConfig) error
+}
+
 type AdapterGetter interface {
 	FromPC(adp *manifest.AdapterConfig) (Adapter, error)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,4 +19,5 @@ func init() {
 	RootCmd.AddCommand(loginCmd)
 	RootCmd.AddCommand(publishCmd)
 	RootCmd.AddCommand(removeCmd)
+	RootCmd.AddCommand(testCmd)
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/c3pm-labs/c3pm/config"
+	"github.com/c3pm-labs/c3pm/ctpm"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test a c3pm project",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pc, err := config.Load(".")
+		if err != nil {
+			return fmt.Errorf("failed to read c3pm.yml: %w", err)
+		}
+		return ctpm.AddDependenciesAndTest(pc)
+	},
+}

--- a/ctpm/test.go
+++ b/ctpm/test.go
@@ -1,0 +1,34 @@
+package ctpm
+
+import (
+	"errors"
+	"fmt"
+	"github.com/c3pm-labs/c3pm/adapter"
+	"github.com/c3pm-labs/c3pm/adapter_interface"
+	"github.com/c3pm-labs/c3pm/config"
+)
+
+func Test(pc *config.ProjectConfig) error {
+	getter := adapter.AdapterGetterImp{}
+	adp, err := getter.FromPC(pc.Manifest.Build.Adapter)
+	if err != nil {
+		return err
+	}
+	adpt, ok := adp.(adapter_interface.AdapterTestable)
+	if !ok {
+		return errors.New("Adapter does not support testing")
+	}
+	return adpt.Test(pc)
+}
+
+func AddDependenciesAndTest(pc *config.ProjectConfig) error {
+	err := addAllDependencies(pc)
+	if err != nil {
+		return fmt.Errorf("error installing dependencies: %w", err)
+	}
+	err = Test(pc)
+	if err != nil {
+		return fmt.Errorf("build failed: %w", err)
+	}
+	return nil
+}

--- a/ctpm/test_test.go
+++ b/ctpm/test_test.go
@@ -1,0 +1,99 @@
+package ctpm_test
+
+import (
+	"bytes"
+	"github.com/c3pm-labs/c3pm/adapter/defaultadapter"
+	"github.com/c3pm-labs/c3pm/config"
+	"github.com/c3pm-labs/c3pm/config/manifest"
+	"github.com/c3pm-labs/c3pm/ctpm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var testSrc = `#include <iostream>
+int main() {
+	std::cout << "Test test" << std::endl;
+	return 0;
+}
+`
+
+var _ = Describe("Test", func() {
+	Describe("Test executable build", func() {
+		projectFolder := getTestFolder("TestTestFolder")
+		projectRoot, _ := filepath.Abs(projectFolder)
+		m := manifest.New()
+		pc := &config.ProjectConfig{Manifest: m, ProjectRoot: projectRoot}
+		var wd string
+
+		BeforeEach(func() {
+			var err error
+			err = os.MkdirAll(projectFolder, os.ModePerm)
+			Ω(err).ShouldNot(HaveOccurred())
+			wd, err = os.Getwd()
+			Ω(err).ShouldNot(HaveOccurred())
+			err = os.Chdir(projectFolder)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+		AfterEach(func() {
+			err := os.Chdir(wd)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+		It("Run test", func() {
+			pc.Manifest.Name = "buildTest"
+			pc.Manifest.Type = manifest.Executable
+			pc.Manifest.Build = &manifest.BuildConfig{
+				Adapter: &manifest.AdapterConfig{
+					Name:    "c3pm",
+					Version: defaultadapter.CurrentVersion,
+				},
+				Config: &defaultadapter.Config{
+					Sources:     []string{"main.cpp"},
+					TestSources: []string{"test.cpp"},
+				},
+			}
+			pc.Manifest.Version, _ = manifest.VersionFromString("1.0.0")
+
+			err := ioutil.WriteFile("main.cpp", []byte(execSrc), 0644)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			err = ioutil.WriteFile("test.cpp", []byte(testSrc), 0644)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			err = ctpm.Test(pc)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Generate cmake scripts", func() {
+			fi, err := os.Stat(".c3pm/cmake/CMakeLists.txt")
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(fi.Size()).To(BeNumerically(">", 0))
+		})
+		It("Generate makefiles", func() {
+			fi, err := os.Stat(".c3pm/build/Makefile")
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(fi.Size()).To(BeNumerically(">", 0))
+		})
+		It("ran tests", func() {
+			fi, err := os.Stat("buildTest_test")
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(fi.Size()).To(BeNumerically(">", 0))
+			buf := bytes.NewBuffer([]byte{})
+			cmd := exec.Command("./buildTest_test")
+			cmd.Stdout = buf
+			err = cmd.Start()
+			Ω(err).ShouldNot(HaveOccurred())
+
+			err = cmd.Wait()
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(buf.String()).To(Equal("Test test\n"))
+		})
+	})
+})


### PR DESCRIPTION
Added new interface that adapter can implement to allow testing
Implemented this interface for default adapter

This add a 'test' command that will build using sources and headers specified in default adapter config.
Example of the new config params:
```yaml
test_sources:
- 'tests/*.cpp'
test_headers:
- 'tests/*.hpp'
```

Binary name will be `$NAME_test`